### PR TITLE
Support for multiple "from"-fields with the same value.

### DIFF
--- a/update_factorio.py
+++ b/update_factorio.py
@@ -75,7 +75,7 @@ def pick_updates(updater_json, factorio_package, from_version, experimental=Fals
 
         updates.append({'from': current_version, 'to': new_version})
         current_version = new_version
- 
+
     return updates, latest
 
 

--- a/update_factorio.py
+++ b/update_factorio.py
@@ -60,6 +60,12 @@ def pick_updates(updater_json, factorio_package, from_version, experimental=Fals
             latest[0] = row['stable']
             continue
 
+    # Get latest experimental version
+    if experimental:
+        for row in updater_json[factorio_package]:
+            if 'from' in row:
+                latest[1] = max(latest[1], row['to'], key=version_key)
+
     # Get available updates
     for row in updater_json[factorio_package]:
         if not experimental and 'from' in row and max(row['from'], current_version, key=version_key) == row['from'] and min(row['to'], latest[0], key=version_key) == row['to']:

--- a/update_factorio.py
+++ b/update_factorio.py
@@ -51,25 +51,30 @@ def get_updater_data(user, token):
 def pick_updates(updater_json, factorio_package, from_version, experimental=False):
     latest = [None, None]
     available_updates = {}
+    current_version = from_version
+    updates = []
+
+    # Get latest stable version
     for row in updater_json[factorio_package]:
         if 'from' not in row:
             latest[0] = row['stable']
             continue
-        available_updates[row['from']] = row['to']
 
-        latest[1] = max(latest[1], row['to'], key=version_key)
+    # Get available updates
+    for row in updater_json[factorio_package]:
+        if not experimental and 'from' in row and row['from'] >= current_version and row['to'] <= latest[0]:
+          available_updates[row['from']] = row['to']
+        elif experimental and 'from' in row and row['from'] >= current_version:
+          available_updates[row['from']] = row['to']
 
-    updates = []
-
-    current_version = from_version
+    # Create update list
     while current_version in available_updates:
         new_version = available_updates[current_version]
         if not experimental and max(current_version, latest[0], key=version_key) == current_version:
             break
-
-        updates.append({'from': current_version, 'to': new_version})
+  
         current_version = new_version
-
+    
     return updates, latest
 
 

--- a/update_factorio.py
+++ b/update_factorio.py
@@ -62,7 +62,7 @@ def pick_updates(updater_json, factorio_package, from_version, experimental=Fals
 
     # Get available updates
     for row in updater_json[factorio_package]:
-        if not experimental and 'from' in row and row['from'] >= current_version and row['to'] <= latest[0]:
+        if not experimental and 'from' in row and max(row['from'], current_version, key=version_key) == row['from'] and min(row['to'], latest[0], key=version_key) == row['to']:
           available_updates[row['from']] = row['to']
         elif experimental and 'from' in row and row['from'] >= current_version:
           available_updates[row['from']] = row['to']

--- a/update_factorio.py
+++ b/update_factorio.py
@@ -70,7 +70,7 @@ def pick_updates(updater_json, factorio_package, from_version, experimental=Fals
     for row in updater_json[factorio_package]:
         if not experimental and 'from' in row and max(row['from'], current_version, key=version_key) == row['from'] and min(row['to'], latest[0], key=version_key) == row['to']:
           available_updates[row['from']] = row['to']
-        elif experimental and 'from' in row and row['from'] >= current_version:
+        elif experimental and 'from' in row and max(row['from'], current_version, key=version_key) == row['from']:
           available_updates[row['from']] = row['to']
 
     # Create update list

--- a/update_factorio.py
+++ b/update_factorio.py
@@ -72,9 +72,10 @@ def pick_updates(updater_json, factorio_package, from_version, experimental=Fals
         new_version = available_updates[current_version]
         if not experimental and max(current_version, latest[0], key=version_key) == current_version:
             break
-  
+
+        updates.append({'from': current_version, 'to': new_version})
         current_version = new_version
-    
+ 
     return updates, latest
 
 


### PR DESCRIPTION
The release of Factorio 0.14.0 added two update possibilities for 0.13.18: 0.13.18 to 0.13.19 and 0.13.18 to 0.14.0. This commit supports that change by respecting the experimental flag earlier. Due to those changes, some declarations are moved to the top of the function and some comments have been added.