### PR TITLE
Fix not-valid escape characters in regex

### DIFF
--- a/update_factorio.py
+++ b/update_factorio.py
@@ -193,7 +193,7 @@ def find_version(args):
 
     if args.for_version is None and args.apply_to is not None:
         version_output = subprocess.check_output([args.apply_to, "--version"], universal_newlines=True)
-        source_version = re.search("Version: (\d+\.\d+\.\d+)", version_output)
+        source_version = re.search("Version: (\\d+\\.\\d+\\.\\d+)", version_output)
         if source_version:
             for_version = source_version.group(1)
             print("Auto-detected starting version as %s from binary." % for_version)


### PR DESCRIPTION
* Python 3.12 upgraded its `DeprecationWarning` (added in Python 3.6) to a `SyntaxWarning` for not-valid escape characters. As a result, the `\d` and `\.` searches are now being flagged as such.
* This fixes them by adding the correct escape level before before a future Python release makes it a hard `SyntaxError`.
