### PR TITLE
Fix updating on Windows by waiting on slave process using `psutil`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ the update with minimal downtime.
 
 ## Usage ##
 
-This is a Python 3 script using a single non-standard library,
-[Requests](http://requests.readthedocs.org/en/latest/). On Windows it also requires [psutil](https://psutil.readthedocs.io/en/latest/).
+This is a Python 3 script using minimal requirements:
+* [Requests](http://requests.readthedocs.org/en/latest/)
+* [psutil](https://psutil.readthedocs.io/en/latest/) (only on Windows)
 
 To install the required dependencies, you should need do no more than run `pip
 install -r requirements.txt`. If this

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ the update with minimal downtime.
 ## Usage ##
 
 This is a Python 3 script using a single non-standard library,
-[Requests](http://requests.readthedocs.org/en/latest/).
+[Requests](http://requests.readthedocs.org/en/latest/). On Windows it also requires [psutil](https://psutil.readthedocs.io/en/latest/).
 
-To install the required dependency, you should need do no more than run `pip
-install requests` (or, in case of emergency, `easy_install requests`). If this
+To install the required dependencies, you should need do no more than run `pip
+install -r requirements.txt`. If this
 does not work, you are encouraged to read the linked documentation and try to
 figure out what's gone wrong.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+psutil; os_name == "nt"

--- a/update_factorio.py
+++ b/update_factorio.py
@@ -5,6 +5,7 @@ import tempfile
 import argparse
 import json
 import subprocess
+import time
 from zipfile import ZipFile
 import urllib.parse as url_parse
 
@@ -231,6 +232,14 @@ def apply_update(args, update):
     update_args = [args.apply_to, "--apply-update", fpath]
     print("Applying update with `%s`." % (" ".join(update_args)))
     verbose_aware_exec(update_args, args.verbose)
+
+    if os.name == "nt":
+        from psutil import process_iter
+
+        print("Waiting for slave process to exit...")
+        while any(p.name() == "Factorio.exe" for p in process_iter()):
+            # Slave process is still running
+            time.sleep(0.5)
 
     if args.delete_after_apply:
         print('Update applied, deleting temporary file %s.' % fpath)


### PR DESCRIPTION
Closes #25
Ref #61

- [x] Test on Windows (multiple updates)
  - Updating on Windows (`core-win64`) is working as expected (successfully waits for the slave process to exit)
- [x] Test on Linux (multiple updates)
  - Updating on Linux (`core-linux64`) is working as expected (without any changes)