### PR TITLE
Initialize download_speed to prevent UnboundLocalError

### DIFF
--- a/update_factorio.py
+++ b/update_factorio.py
@@ -169,6 +169,7 @@ def fetch_update(output_path, url, ignore_existing_files, verify_zip):
 
     total_size = int(r.headers.get('content-length', 0)) # get content length
     downloaded_size = 0
+    download_speed = 0
     bar_width = 50     # could use os.get_terminal_size().columns to adapt the screen width
     start_time = time.time()  # time of start download
     with open(fpath, 'wb') as fd:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "C:\test\factorio-updater\update_factorio.py", line 327, in <module>
    sys.exit(main())
  File "C:\test\factorio-updater\update_factorio.py", line 318, in main
    apply_update(args, u)
  File "C:\test\factorio-updater\update_factorio.py", line 248, in apply_update
    fpath = fetch_update(args.output_path, url, args.ignore_existing_files, args.verify_zip)
  File "C:\test\factorio-updater\update_factorio.py", line 190, in fetch_update
    print(f"\r[{'█' * bar_block}{' ' * (bar_width - bar_block)}] {downloaded_size / 2 ** 20:.2f}/{total_size / 2 ** 20:.2f} MiB  {download_speed / 2 ** 20:.2f} MiB/s", end='')
UnboundLocalError: local variable 'download_speed' referenced before assignment
```